### PR TITLE
Refactor checkers and less channels in CalculateOdds

### DIFF
--- a/API/internal/calculateOdds_test.go
+++ b/API/internal/calculateOdds_test.go
@@ -65,15 +65,26 @@ func TestCalculateOdds(t *testing.T) {
 }
 
 func BenchmarkCalculateOdds(b *testing.B) {
-	b.ResetTimer()
-	req := typing.Request{
-		PlayerHand:   []string{"AH", "AS"},
-		OpponentHand: []string{"KC", "KD"},
+	hands := [][]string{
+		{"KC", "KD"},
+		{"KC", "KD"},
+		{"KC", "KD"},
+		{"KC", "KD"},
+		{"KC", "KD"},
+		{"KC", "KD"},
 	}
-
-	cardReq, err := req.ConvertsRequest()
-	assert.NoError(b, err)
+	playerHand, _ := typing.FromStrings([]string{"AH", "AS"})
+	opponentHands := make([][]typing.Card, 0)
+	for _, hand := range hands {
+		temp, _ := typing.FromStrings(hand)
+		opponentHands = append(opponentHands, temp)
+	}
+	b.ResetTimer()
+	req := typing.CardRequest{
+		PlayerHand:    playerHand,
+		OpponentHands: opponentHands,
+	}
 	for i := 0; i < b.N; i++ {
-		internal.CalculateOdds(cardReq)
+		internal.CalculateOdds(req)
 	}
 }

--- a/API/internal/checkers.go
+++ b/API/internal/checkers.go
@@ -5,7 +5,7 @@ var checkers = []func(a []int) (int, bool){isStraightFlush, isQuads, isFullHouse
 func isPair(cards []int) (int, bool) {
 	for i := 1; i < len(cards); i++ {
 		if cards[i]/4 == cards[i-1]/4 {
-			return Pair + (cards[i] / 4), true
+			return Pair + getPriority(0, cards[i]), true
 		}
 	}
 	return 0, false
@@ -22,7 +22,7 @@ func isTwoPair(cards []int) (int, bool) {
 
 	if pairs == 2 {
 		// if there are 2 pairs, the second and fourth card are always part of them
-		return TwoPair + (13*(cards[1]/4+1) + (cards[3] / 4)), true
+		return TwoPair + getPriority(cards[1], cards[3]), true
 	}
 	return 0, false
 }
@@ -30,7 +30,7 @@ func isTwoPair(cards []int) (int, bool) {
 func isSet(cards []int) (int, bool) {
 	for i := 2; i < len(cards); i++ {
 		if cards[i]/4 == cards[i-1]/4 && cards[i]/4 == cards[i-2]/4 {
-			return Set + (cards[i] / 4), true
+			return Set + getPriority(0, cards[i]), true
 		}
 	}
 	return 0, false
@@ -42,10 +42,10 @@ func isFullHouse(cards []int) (int, bool) {
 	}
 	if cards[0]/4 == cards[1]/4 && cards[3]/4 == cards[4]/4 && (cards[2]/4 == cards[0]/4 || cards[2]/4 == cards[4]/4) {
 		if cards[2]/4 == cards[0]/4 {
-			return FullHouse + (13*(cards[2]/4+1) + (cards[4] / 4)), true
+			return FullHouse + getPriority(cards[2], cards[4]), true
 		} else {
 
-			return FullHouse + (13*(cards[2]/4+1) + (cards[0] / 4)), true
+			return FullHouse + getPriority(cards[2], cards[0]), true
 		}
 	}
 	return 0, false
@@ -93,7 +93,12 @@ func isQuads(cards []int) (int, bool) {
 		return 0, false
 	}
 	if cards[1]/4 == cards[2]/4 && cards[1]/4 == cards[3]/4 && (cards[0]/4 == cards[1]/4 || cards[4]/4 == cards[1]/4) {
-		return Quads + (cards[1] / 4), true
+		return Quads + getPriority(0, cards[1]), true
 	}
 	return 0, false
+}
+
+func getPriority(a, b int) int {
+	// if a == 2 then the value it represents is 2
+	return (a/4+2)*14 + (b/4 + 2)
 }

--- a/API/internal/checkers_test.go
+++ b/API/internal/checkers_test.go
@@ -30,11 +30,12 @@ func TestIsStraight(t *testing.T) {
 
 func TestIsTwoPair(t *testing.T) {
 	cards, err := typing.FromStrings([]string{"9D", "9S", "7C", "5S", "5D"})
+	priority := getPriority(cards[1].ToInt(), cards[3].ToInt())
 	intCards := typing.ToInts(cards)
 	assert.NoError(t, err)
 	combo, is := isTwoPair(intCards)
 	assert.Equal(t, true, is)
-	assert.Equal(t, TwoPair, combo)
+	assert.Equal(t, TwoPair+priority, combo)
 }
 
 func TestCardSort(t *testing.T) {


### PR DESCRIPTION
refactored checkers so that they use getPriority for their return values.

#2 
Changed CalculateOdds to only use 1 channel and limits the amount of created go routines to the number of opponent hands. This slows down how quickly we process single-hand requests, but greatly decreases complexity.